### PR TITLE
Use tempfile to create the temporary image

### DIFF
--- a/bin/canga
+++ b/bin/canga
@@ -9,6 +9,7 @@ require "thor"
 require "fileutils"
 require "digest"
 require "cangallo"
+require "tempfile"
 
 require "pp"
 
@@ -132,14 +133,15 @@ class Canga < Thor
     parent_path = File.expand_path(repo.image_path(sha256))
 
     # temp image path
-    temp_image = File.join("repo", "temp-1.qcow2")
+    temp_image = Tempfile.new([File.basename(file), '.qcow2'])
+    temp_image.close
 
-    Qcow2.create_from_base(parent_path, temp_image)
+    Qcow2.create_from_base(parent_path, temp_image.path)
 
-    rc = LibGuestfs.virt_customize(temp_image, cangafile.libguestfs_commands)
+    rc = LibGuestfs.virt_customize(temp_image.path, cangafile.libguestfs_commands)
     exit(-1) if !rc
 
-    rc = LibGuestfs.virt_sparsify(temp_image)
+    rc = LibGuestfs.virt_sparsify(temp_image.path)
     exit(-1) if !rc
 
     data = {}
@@ -151,10 +153,10 @@ class Canga < Thor
 
     data["cangafile"] = cangafile.data
 
-    repo.add_image(temp_image, data)
+    repo.add_image(temp_image.path, data)
 
     puts "Deleting temporary image"
-    FileUtils.rm(temp_image)
+    temp_image.delete
   end
 
   desc "fetch", "download the index of the repository"


### PR DESCRIPTION
This should ensure there are no conflicts in the event that two images
are being built simultaneously.  Let me know what you think.
