### PR TITLE
Add functionality for export

### DIFF
--- a/bin/canga
+++ b/bin/canga
@@ -159,6 +159,23 @@ class Canga < Thor
     repo = $cangallo.repo(options[:repo])
     repo.pull(name)
   end
+  
+  desc "export IMAGE OUTPUT", "export an image to a file"
+  option :format, :desc => "format for output image", :default => :qcow2, :alliases => :f
+  option :compress, :desc => "compress output qcow2 image", :default => false, :alliases => :c
+  def export(image, output)
+    repo = $cangallo.repo(options[:repo])
+    sha256 = repo.find(image)
+
+    if !sha256
+      STDERR.puts "Image not found"
+      exit(-1)
+    end
+
+    path = File.expand_path(repo.image_path(sha256))
+    
+    Cangallo::Qcow2.new(path).convert(output,options)
+  end
 
 end
 

--- a/lib/cangallo/qcow2.rb
+++ b/lib/cangallo/qcow2.rb
@@ -25,6 +25,15 @@ class Cangallo
       copy(destination, :parent => parent, :compress => true)
     end
 
+    def convert(destination, options = {})
+      command = [:convert]
+      command << '-c' if options[:compress]
+      command << "-O #{options[:format]}" if options[:format]
+      command += [@path, destination]
+
+      execute(*command)
+    end
+
     def copy(destination = nil, options = {})
       ops = {
         :parent => nil,


### PR DESCRIPTION
Export will default to an uncompressed qcow but this can be set to
either compress the qcow or output a raw file.  More functionality can
be added but for now I kept it simple.
