### PR TITLE
gh-10

### DIFF
--- a/bin/canga
+++ b/bin/canga
@@ -95,7 +95,7 @@ class Canga < Thor
   desc "build CANGAFILE", "create a new image using a Cangafile"
   def build(file)
     repo = $cangallo.repo(options[:repo])
-    cangafile = Cangafile.new(file)
+    cangafile = Cangallo::Cangafile.new(file)
 
     puts cangafile.libguestfs_commands
 
@@ -114,10 +114,10 @@ class Canga < Thor
 
     Cangallo::Qcow2.create_from_base(parent_path, temp_image.path)
 
-    rc = LibGuestfs.virt_customize(temp_image.path, cangafile.libguestfs_commands)
+    rc = Cangallo::LibGuestfs.virt_customize(temp_image.path, cangafile.libguestfs_commands)
     exit(-1) if !rc
 
-    rc = LibGuestfs.virt_sparsify(temp_image.path)
+    rc = Cangallo::LibGuestfs.virt_sparsify(temp_image.path)
     exit(-1) if !rc
 
     data = {}


### PR DESCRIPTION
Fix missing reference when Cangallo was changed from module to a class

Tested on:
https://github.com/microns-ariadne/ariadne-images/blob/ce144062de4d0e6bc1c979927ec4ca037b3cc42d/canga_files/Cangafile.cloud-init

https://github.com/microns-ariadne/ariadne-images/blob/ce144062de4d0e6bc1c979927ec4ca037b3cc42d/canga_files/Cangafile.nebula-context
