### PR TITLE
restrict version regex to maj.min.patch version

### DIFF
--- a/lib/cangallo/libguestfs.rb
+++ b/lib/cangallo/libguestfs.rb
@@ -96,7 +96,7 @@ class Cangallo
     def self.version
       str = `virt-customize --version`
 
-      m = str.match(/^virt-customize (.*)$/)
+      m = str.match(/^virt-customize (\d+\.\d+\.\d+).*$/)
 
       if m
         m[1]


### PR DESCRIPTION
Current regex breaks on libguestfs 1.32.7 from CentOS 7 Continuous
Release repo given that they compile it with:
```
$ ./configure --with-extra='rhel=7,release=3.el7.centos,libvirt'
```
Which produces:
```
$ yum-config-manager --enable cr
$ yum clean all && yum install libguestfs{,-tools}
$ virt-customize --version
virt-customize 1.32.7rhel=7,release=3.el7.centos,libvirt
```