### PR TITLE
Aliases rm/rmtag on del/deltag

### DIFF
--- a/bin/canga
+++ b/bin/canga
@@ -31,6 +31,7 @@ $cangallo = Cangallo.new
 
 class Canga < Thor
   map ['--version', '-V'] => :__print_version
+  map 'rm' => :del, 'rmtag' => :deltag
 
   desc "--version, -V", "show version"
   def __print_version


### PR DESCRIPTION
This simple patch introduces aliases on following commands:
canga rm -> canga del
canga rmtag -> canga deltag