### PR TITLE
Use virt-customize's delete command for delete

### DIFF
--- a/lib/cangallo/cangafile.rb
+++ b/lib/cangallo/cangafile.rb
@@ -60,7 +60,7 @@ class Cangallo
 
       "delete" => {
         "action" => lambda do |input|
-          add_head "run-command rm -rf #{input}"
+          add_head "delete #{input}"
         end
       },
 


### PR DESCRIPTION
If delete is implemented as a rm -rf inside the run-command, it works in 99 % use-cases. But, it doesn't work for `/etc/resolv.conf` when it's essential to deliver images with clean resolver configuration. Following simple change use virt-customize's **delete** for delete, instead of **run-command**.

## Why

virt-customize has the networking enabled by default, so that yum/apt-get works. But, for each run-command, it saves original resolv.conf, puts own configuration to have resolver working and after run-comand, it restores the original resolv.conf. So, it's impossible to manipulate/delete the resolv.conf inside the run-command. Delete must be done by delete command, not by calling the rm -rf.

```
[   3.1] Running: rm -rf /etc/resolv.conf
running command:
exec >>'/tmp/builder.log' 2>&1


rm -rf /etc/resolv.conf

guestfsd: main_loop: new request, len 0x68
commandrvf: stdout=n stderr=n flags=0x0
commandrvf: mount --bind /dev /sysroot/dev
...
renaming /sysroot/etc/resolv.conf to /sysroot/etc/ve0ukj7y          <<<---
commandrvf: stdout=n stderr=n flags=0x0
commandrvf: cp /etc/resolv.conf /sysroot/etc/resolv.conf            <<<---
commandrvf: stdout=y stderr=y flags=0x40000
commandrvf: /bin/sh -c "exec >>'/tmp/builder.log' 2>&1


rm -rf /etc/resolv.conf
"
commandrvf: stdout=n stderr=n flags=0x0
...
commandrvf: umount /sysroot/dev
renaming /sysroot/etc/ve0ukj7y to /sysroot/etc/resolv.conf          <<<---
guestfsd: main_loop: proc 111 (sh) took 0.06 seconds
[   3.1] Deleting: /etc/resolv.conf
guestfsd: main_loop: new request, len 0x40
guestfsd: main_loop: proc 113 (glob_expand) took 0.00 seconds
guestfsd: main_loop: new request, len 0x3c
commandrvf: stdout=n stderr=y flags=0x0
commandrvf: rm -rf /sysroot/etc/resolv.conf
guestfsd: main_loop: proc 31 (rm_rf) took 0.00 seconds
guestfsd: main_loop: new request, len 0x3c
guestfsd: main_loop: proc 67 (download) took 0.00 seconds
guestfsd: main_loop: new request, len 0x54
commandrvf: stdout=e stderr=y flags=0x10000
commandrvf: /bin/sh -c "fuser -k /sysroot"
guestfsd: error: 
guestfsd: main_loop: proc 76 (debug) took 0.00 seconds

```