### PR TITLE
qcow2/create: get backing storage format from qemu-img

### DIFF
--- a/lib/cangallo/qcow2.rb
+++ b/lib/cangallo/qcow2.rb
@@ -45,6 +45,12 @@ class Cangallo
       end
     end
 
+    def self.qemu_img_backing_file_parameter(path)
+      q = Qcow2.new(path)
+      format = q.info['format']
+      "-o backing_file=#{path},backing_fmt=#{format}"
+    end
+
     def initialize(path=nil)
       @path=path
     end
@@ -152,18 +158,12 @@ class Cangallo
     end
 
     def self.create_from_base(origin, destination, size=nil)
-      cmd = [:create, '-f qcow2', "-o backing_file=#{origin}", destination]
-      cmd << size if size
-
-      execute(*cmd)
+      create(destination, origin, size)
     end
 
     def self.create(image, parent=nil, size=nil)
       cmd = [:create, '-f qcow2']
-      if parent
-        backing_fmt = File.extname(File.basename(parent)).delete_prefix('.')
-        cmd << "-o backing_file=#{parent},backing_fmt=#{backing_fmt}"
-      end
+      cmd << Qcow2.qemu_img_backing_file_parameter(parent) if parent
       cmd << image
       cmd << size if size
       execute(*cmd)

--- a/spec/qcow2_spec.rb
+++ b/spec/qcow2_spec.rb
@@ -1,4 +1,3 @@
-
 # vim:ts=2:sw=2
 
 #$: << 'lib/cangallo'
@@ -6,6 +5,8 @@ require 'spec_helper'
 
 require 'qcow2'
 require 'fileutils'
+
+IMAGE_SIZE = 100 * 1024 * 1024
 
 describe Cangallo::Qcow2 do
   before :all do
@@ -16,70 +17,119 @@ describe Cangallo::Qcow2 do
     FileUtils.rm_rf(@tmpdir)
   end
 
-  context "creating the base image" do
+  context 'creating the base image' do
     before :all do
-      @path = File.join(@tmpdir, 'base.qcow2')
-      Cangallo::Qcow2.create(@path, nil, 100*1024*1024) # 100 Mb
+      @qcow2_path = File.join(@tmpdir, 'base.qcow2')
+      Cangallo::Qcow2.create(@qcow2_path, nil, IMAGE_SIZE) # 100 Mb
+
+      q = Cangallo::Qcow2.new(@qcow2_path)
+
+      @raw_path = File.join(@tmpdir, 'base.raw')
+
+      f = File.open(@raw_path, 'w')
+      f.seek(IMAGE_SIZE - 1)
+      f.write("\x00")
+      f.close
     end
 
-    it "should be able to create it" do
-      expect(File).to exist(@path)
+    it 'should be able to create it' do
+      expect(File).to exist(@qcow2_path)
+      expect(File).to exist(@raw_path)
     end
 
-    it 'should get proper info' do
-      qcow2 = Cangallo::Qcow2.new(@path)
+    it 'should get proper info (qcow2)' do
+      qcow2 = Cangallo::Qcow2.new(@qcow2_path)
 
       info = qcow2.info
       expect(info).not_to eq(nil)
 
-      expect(info['virtual-size']).to eq(100*1024*1024)
-      expect(info['cluster-size']).to eq(65536)
+      expect(info['virtual-size']).to eq(IMAGE_SIZE)
+      expect(info['cluster-size']).to eq(65_536)
       expect(info['format']).to eq('qcow2')
-      expect(info['actual-size']).to eq(200704)
+      expect(info['actual-size']).to eq(200_704)
     end
 
-    if ENV['TRAVIS'] != 'true'
-      it 'should be able to compute sha1' do
-        qcow2 = Cangallo::Qcow2.new(@path)
+    it 'should get proper info (raw)' do
+      qcow2 = Cangallo::Qcow2.new(@raw_path)
 
-        sha1 = qcow2.sha1
-        expect(sha1).to eq("2c2ceccb5ec5574f791d45b63c940cff20550f9a")
-      end
+      info = qcow2.info
+      expect(info).not_to eq(nil)
+
+      expect(info['virtual-size']).to eq(IMAGE_SIZE)
+      expect(info['cluster-size']).to eq(nil)
+      expect(info['format']).to eq('raw')
+      expect(info['actual-size']).to eq(4096)
+    end
+
+    it 'should be able to compute sha1 (qcow2)' do
+      qcow2 = Cangallo::Qcow2.new(@qcow2_path)
+
+      sha1 = qcow2.sha1
+      expect(sha1).to eq('2c2ceccb5ec5574f791d45b63c940cff20550f9a')
+    end
+
+    it 'should be able to compute sha1 (raw)' do
+      qcow2 = Cangallo::Qcow2.new(@raw_path)
+
+      sha1 = qcow2.sha1
+      expect(sha1).to eq('2c2ceccb5ec5574f791d45b63c940cff20550f9a')
     end
   end
 
-  context "with the child image" do
+  context 'with the child image' do
     before :all do
-      @path = File.join(@tmpdir, 'child.qcow2')
+      @qcow2_path = File.join(@tmpdir, 'child_qcow2.qcow2')
+      @raw_path = File.join(@tmpdir, 'child_raw.qcow2')
       # 200 Mb
-      Cangallo::Qcow2.create(@path, File.join(@tmpdir, 'base.qcow2'), 200*1024*1024)
+      Cangallo::Qcow2.create(@qcow2_path, File.join(@tmpdir, 'base.qcow2'), 2 * IMAGE_SIZE)
+      Cangallo::Qcow2.create(@raw_path, File.join(@tmpdir, 'base.raw'), 2 * IMAGE_SIZE)
     end
 
-    it "should be able to create it" do
-      expect(File).to exist(@path)
+    it 'should be able to create it' do
+      expect(File).to exist(@qcow2_path)
+      expect(File).to exist(@raw_path)
     end
 
-    it 'should get proper info' do
-      qcow2 = Cangallo::Qcow2.new(@path)
+    it 'should get proper info (qcow2)' do
+      qcow2 = Cangallo::Qcow2.new(@qcow2_path)
 
       info = qcow2.info
       expect(info).not_to eq(nil)
 
-      expect(info['virtual-size']).to eq(200*1024*1024)
-      expect(info['cluster-size']).to eq(65536)
+      expect(info['virtual-size']).to eq(2 * IMAGE_SIZE)
+      expect(info['cluster-size']).to eq(65_536)
       expect(info['format']).to eq('qcow2')
-      expect(info['actual-size']).to eq(200704)
+      expect(info['actual-size']).to eq(200_704)
       expect(File.basename(info['backing-filename'])).to eq('base.qcow2')
+      expect(File.basename(info['backing-filename-format'])).to eq('qcow2')
     end
 
-    if ENV['TRAVIS'] != 'true'
-      it 'should be able to compute sha1' do
-        qcow2 = Cangallo::Qcow2.new(@path)
+    it 'should get proper info (raw)' do
+      qcow2 = Cangallo::Qcow2.new(@raw_path)
 
-        sha1 = qcow2.sha1
-        expect(sha1).to eq("fd7c5327c68fcf94b62dc9f58fc1cdb3c8c01258")
-      end
+      info = qcow2.info
+      expect(info).not_to eq(nil)
+
+      expect(info['virtual-size']).to eq(2 * IMAGE_SIZE)
+      expect(info['cluster-size']).to eq(65_536)
+      expect(info['format']).to eq('qcow2')
+      expect(info['actual-size']).to eq(200_704)
+      expect(File.basename(info['backing-filename'])).to eq('base.raw')
+      expect(File.basename(info['backing-filename-format'])).to eq('raw')
+    end
+
+    it 'should be able to compute sha1 (qcow2)' do
+      qcow2 = Cangallo::Qcow2.new(@qcow2_path)
+
+      sha1 = qcow2.sha1
+      expect(sha1).to eq('fd7c5327c68fcf94b62dc9f58fc1cdb3c8c01258')
+    end
+
+    it 'should be able to compute sha1 (raw)' do
+      qcow2 = Cangallo::Qcow2.new(@raw_path)
+
+      sha1 = qcow2.sha1
+      expect(sha1).to eq('fd7c5327c68fcf94b62dc9f58fc1cdb3c8c01258')
     end
   end
 end
-


### PR DESCRIPTION
Instead of using file extension the format is retrieved from qemu-img info command.

Also added some tests to check that it works.

There are other functions that need to be changed but they also need tests. This will be done in another PR.